### PR TITLE
Remove GenerateSerializationAssemblies

### DIFF
--- a/PopOptBox.Base/PopOptBox.Base.csproj
+++ b/PopOptBox.Base/PopOptBox.Base.csproj
@@ -11,11 +11,7 @@
         <AssemblyName>PopOptBox.Base</AssemblyName>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-      <GenerateSerializationAssemblies>On</GenerateSerializationAssemblies>
-    </PropertyGroup>
-
-    <ItemGroup>
+  <ItemGroup>
       <PackageReference Include="MathNet.Numerics" Version="4.8.1" />
       <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.10.0-preview5.19224.8" />
     </ItemGroup>


### PR DESCRIPTION
Turning the *GenerateSerializationAssemblies* flag **on** causes problems in our build processes. It would be great if it could be removed.

Do you have anything against it? If not, please merge these changes.
Thank you.